### PR TITLE
Add Unit Tests for Component Screens (SignUp, Login, Parking, EditVehicle, and ReservationConfirmation)

### DIFF
--- a/screens/ParkingScreen.js
+++ b/screens/ParkingScreen.js
@@ -13,7 +13,7 @@
  */
 import React from "react";
 import { View, Text, StyleSheet } from "react-native";
-import ParkingMap from "../components/ParkingMap/ParkingMap";
+import ParkingMap from "../src/components/ParkingMap/ParkingMap"; // Josh: fix file path for ParkingScreen.test.js unit test
 
 const ParkingScreen = ({ navigation }) => {
   return (

--- a/screens/__tests__/EditVehicleScreen.test.js
+++ b/screens/__tests__/EditVehicleScreen.test.js
@@ -1,0 +1,128 @@
+import React from "react";
+import { render, fireEvent, waitFor, act } from "@testing-library/react-native";
+import EditVehicleScreen from "../EditVehicleScreen";
+import { Alert } from "react-native";
+
+// 🔧 Mock Firestore
+jest.mock("firebase/firestore", () => ({
+  doc: jest.fn(),
+  getDoc: jest.fn(() => Promise.resolve({
+    exists: () => true,
+    data: () => ({
+      vehicles: [
+        { make: "Toyota", model: "Camry", year: "2020", licensePlate: "XYZ123", imageUrl: null }
+      ]
+    })
+  })),
+  setDoc: jest.fn(() => Promise.resolve())
+}));
+
+// 🔧 Mock Firebase Auth
+jest.mock("../../firebaseConfig", () => ({
+  db: {},
+  auth: { currentUser: { uid: "test-user-id" } }
+}));
+
+// 🔧 Mock Firebase Storage
+jest.mock("firebase/storage", () => ({
+  getStorage: jest.fn(() => ({
+    app: { options: { storageBucket: "test-bucket" } }
+  })),
+  ref: jest.fn(),
+  deleteObject: jest.fn(() => Promise.resolve())
+}));
+
+// 🔧 Mock Image Picker and FileSystem
+jest.mock("expo-image-picker", () => ({
+  launchImageLibraryAsync: jest.fn(),
+  launchCameraAsync: jest.fn(),
+  requestCameraPermissionsAsync: jest.fn(() => Promise.resolve({ granted: true })),
+  MediaTypeOptions: { Images: "Images" }
+}));
+
+jest.mock("expo-file-system", () => ({
+  getInfoAsync: jest.fn(() => Promise.resolve({ size: 1000 })),
+  uploadAsync: jest.fn(() => Promise.resolve({ status: 200 }))
+}));
+
+jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+describe("EditVehicleScreen", () => {
+  const mockNavigation = { navigate: jest.fn() };
+  const mockRoute = {
+    params: {
+      index: 0,
+      vehicle: {
+        make: "Toyota",
+        model: "Camry",
+        year: "2020",
+        licensePlate: "XYZ123",
+        imageUrl: null
+      }
+    }
+  };
+
+  it("renders inputs with prefilled values and updates vehicle info", async () => {
+    const { getByPlaceholderText, getByText } = render(
+      <EditVehicleScreen route={mockRoute} navigation={mockNavigation} />
+    );
+
+    const makeInput = getByPlaceholderText("Make");
+    const modelInput = getByPlaceholderText("Model");
+    const yearInput = getByPlaceholderText("Year");
+    const plateInput = getByPlaceholderText("License Plate");
+
+    // Simulate input changes
+    fireEvent.changeText(makeInput, "Honda");
+    fireEvent.changeText(modelInput, "Civic");
+    fireEvent.changeText(yearInput, "2022");
+    fireEvent.changeText(plateInput, "ABC789");
+
+    const saveButton = getByText("Save Changes");
+
+    await act(async () => {
+      fireEvent.press(saveButton);
+    });
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith("Vehicle updated successfully!");
+      expect(mockNavigation.navigate).toHaveBeenCalledWith("My Account");
+    });
+  });
+
+  it("shows error alert for invalid year", async () => {
+    const { getByPlaceholderText, getByText } = render(
+      <EditVehicleScreen route={mockRoute} navigation={mockNavigation} />
+    );
+
+    const yearInput = getByPlaceholderText("Year");
+    fireEvent.changeText(yearInput, "abcd");
+
+    const saveButton = getByText("Save Changes");
+
+    await act(async () => {
+      fireEvent.press(saveButton);
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith("Error", "Please enter a valid year (e.g., 2025).");
+  });
+
+  it("shows error alert when fields are empty", async () => {
+    const { getByPlaceholderText, getByText } = render(
+      <EditVehicleScreen route={mockRoute} navigation={mockNavigation} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText("Make"), "");
+    fireEvent.changeText(getByPlaceholderText("Model"), "");
+    fireEvent.changeText(getByPlaceholderText("Year"), "");
+    fireEvent.changeText(getByPlaceholderText("License Plate"), "");
+
+    const saveButton = getByText("Save Changes");
+
+    await act(async () => {
+      fireEvent.press(saveButton);
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith("Error", "All fields are required.");
+  });
+});

--- a/screens/__tests__/LoginScreen.test.js
+++ b/screens/__tests__/LoginScreen.test.js
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import LoginScreen from "../LoginScreen";
+import { Alert } from "react-native";
+
+// 🔧 Mock Firebase Authentication
+jest.mock("firebase/auth", () => ({
+  signInWithEmailAndPassword: jest.fn(),
+}));
+
+// 🔧 Mock firebaseConfig.js
+jest.mock("../../firebaseConfig", () => ({
+  auth: { currentUser: null },
+}));
+
+// 🔧 Spy on Alert
+jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+describe("<LoginScreen />", () => {
+  const mockNavigation = {
+    navigate: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders login inputs and buttons correctly", () => {
+    const { getByPlaceholderText, getByText } = render(
+      <LoginScreen navigation={mockNavigation} />
+    );
+
+    expect(getByPlaceholderText("Enter your email")).toBeTruthy();
+    expect(getByPlaceholderText("Enter your password")).toBeTruthy();
+    expect(getByText("Sign In")).toBeTruthy();
+    expect(getByText("Don’t have an account?")).toBeTruthy();
+    expect(getByText("Forgot Password?")).toBeTruthy();
+  });
+
+  it("navigates to SignUp screen", () => {
+    const { getByText } = render(<LoginScreen navigation={mockNavigation} />);
+    fireEvent.press(getByText("Don’t have an account?"));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith("SignUp");
+  });
+
+  it("navigates to ResetPassword screen", () => {
+    const { getByText } = render(<LoginScreen navigation={mockNavigation} />);
+    fireEvent.press(getByText("Forgot Password?"));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith("ResetPassword");
+  });
+
+  it("logs in and navigates to Home on valid credentials", async () => {
+    const { signInWithEmailAndPassword } = require("firebase/auth");
+    signInWithEmailAndPassword.mockResolvedValueOnce({ user: { uid: "123" } });
+
+    const { getByPlaceholderText, getByText } = render(
+      <LoginScreen navigation={mockNavigation} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText("Enter your email"), "user@example.com");
+    fireEvent.changeText(getByPlaceholderText("Enter your password"), "password123");
+
+    await waitFor(() => fireEvent.press(getByText("Sign In")));
+
+    expect(signInWithEmailAndPassword).toHaveBeenCalledWith(
+      expect.anything(),
+      "user@example.com",
+      "password123"
+    );
+    expect(mockNavigation.navigate).toHaveBeenCalledWith("Home");
+  });
+
+  it("shows alert on failed login", async () => {
+    const { signInWithEmailAndPassword } = require("firebase/auth");
+    signInWithEmailAndPassword.mockRejectedValueOnce(new Error("Invalid credentials"));
+
+    const { getByPlaceholderText, getByText } = render(
+      <LoginScreen navigation={mockNavigation} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText("Enter your email"), "bad@example.com");
+    fireEvent.changeText(getByPlaceholderText("Enter your password"), "wrongpass");
+
+    await waitFor(() => fireEvent.press(getByText("Sign In")));
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      "Login failed",
+      "Invalid email or password. Please try again."
+    );
+  });
+});

--- a/screens/__tests__/ParkingScreen.test.js
+++ b/screens/__tests__/ParkingScreen.test.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import ParkingScreen from "../ParkingScreen";
+
+// Mock ParkingMap component to isolate the test
+jest.mock("../../src/components/ParkingMap/ParkingMap", () => {
+    return jest.fn(() => {
+      return <></>;
+    });
+});
+  
+import ParkingMap from "../../src/components/ParkingMap/ParkingMap";
+
+describe("<ParkingScreen />", () => {
+  const mockNavigation = { navigate: jest.fn() };
+
+  it("renders the title and ParkingMap component", () => {
+    const { getByText } = render(<ParkingScreen navigation={mockNavigation} />);
+
+    // Confirm title is rendered
+    expect(getByText("Parking Garage Map")).toBeTruthy();
+
+    // Confirm ParkingMap component is called with correct props
+    expect(ParkingMap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parkingLot: "Parking Garage",
+        navigation: mockNavigation,
+      }),
+      {}
+    );
+  });
+});

--- a/screens/__tests__/ReservationConfirmationScreen.test.js
+++ b/screens/__tests__/ReservationConfirmationScreen.test.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import ReservationConfirmationScreen from "../ReservationConfirmationScreen";
+
+// 🔧 Mock useNavigation from react-navigation
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+describe("<ReservationConfirmationScreen />", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders confirmation title and message", () => {
+    const { getByText } = render(<ReservationConfirmationScreen />);
+
+    expect(getByText("Reservation Confirmed")).toBeTruthy();
+    expect(
+      getByText("You have 1 hour to park in your reserved spot before it is lost.")
+    ).toBeTruthy();
+  });
+
+  it("navigates to Home when button is pressed", () => {
+    const { getByText } = render(<ReservationConfirmationScreen />);
+    fireEvent.press(getByText("Back to Home"));
+    expect(mockNavigate).toHaveBeenCalledWith("Home");
+  });
+});

--- a/screens/__tests__/ResetPasswordScreen.test.js
+++ b/screens/__tests__/ResetPasswordScreen.test.js
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import ResetPasswordScreen from "../ResetPasswordScreen";
+import { sendPasswordResetEmail } from "firebase/auth";
+import { Alert } from "react-native";
+
+// firebaseConfig and navigation
+jest.mock("../../firebaseConfig", () => ({
+  auth: { currentUser: { email: "test@example.com", uid: "12345" } },
+}));
+
+// sendPasswordResetEmail from Firebase
+jest.mock("firebase/auth", () => ({
+  sendPasswordResetEmail: jest.fn(),
+}));
+
+// Alert
+jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+describe("<ResetPasswordScreen />", () => {
+  const mockNavigation = {
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders input and buttons correctly", () => {
+    const { getByPlaceholderText, getByText } = render(
+      <ResetPasswordScreen navigation={mockNavigation} />
+    );
+
+    expect(getByPlaceholderText("Email")).toBeTruthy();
+    expect(getByText("Send Reset Email")).toBeTruthy();
+    expect(getByText("Back")).toBeTruthy();
+  });
+
+  it("shows alert and navigates back on successful reset", async () => {
+    sendPasswordResetEmail.mockResolvedValueOnce();
+
+    const { getByPlaceholderText, getByText } = render(
+      <ResetPasswordScreen navigation={mockNavigation} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText("Email"), "user@example.com");
+    fireEvent.press(getByText("Send Reset Email"));
+
+    await waitFor(() => {
+      expect(sendPasswordResetEmail).toHaveBeenCalledWith(
+        expect.anything(),
+        "user@example.com"
+      );
+      expect(Alert.alert).toHaveBeenCalledWith("Password reset email sent!");
+      expect(mockNavigation.goBack).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error alert if reset fails", async () => {
+    sendPasswordResetEmail.mockRejectedValueOnce(new Error("Reset failed"));
+
+    const { getByPlaceholderText, getByText } = render(
+      <ResetPasswordScreen navigation={mockNavigation} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText("Email"), "fail@example.com");
+    fireEvent.press(getByText("Send Reset Email"));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith("Reset failed");
+    });
+  });
+
+  it("navigates to Login when Back is pressed", () => {
+    const { getByText } = render(
+      <ResetPasswordScreen navigation={mockNavigation} />
+    );
+
+    fireEvent.press(getByText("Back"));
+    expect(mockNavigation.navigate).toHaveBeenCalledWith("Login");
+  });
+});

--- a/screens/__tests__/signUpScreen.test.js
+++ b/screens/__tests__/signUpScreen.test.js
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import SignUpScreen from "../signUpScreen";
+import { Alert } from "react-native";
+
+// 🔧 Mock Firebase Auth
+jest.mock("firebase/auth", () => ({
+  createUserWithEmailAndPassword: jest.fn(),
+  signInWithEmailAndPassword: jest.fn(),
+}));
+
+// 🔧 Mock Firebase config
+jest.mock("../../firebaseConfig", () => ({
+  auth: {},
+}));
+
+// 🔧 Spy on Alert
+jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+describe("<SignUpScreen />", () => {
+  const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders inputs and buttons", () => {
+    const { getByPlaceholderText, getByText } = render(
+      <SignUpScreen navigation={mockNavigation} />
+    );
+
+    expect(getByPlaceholderText("Enter your email")).toBeTruthy();
+    expect(getByPlaceholderText("Enter your password")).toBeTruthy();
+    expect(getByText("Create Account")).toBeTruthy();
+    expect(getByText("Back to Login")).toBeTruthy();
+  });
+
+  it("shows alert if terms not accepted", async () => {
+    const { getByText } = render(<SignUpScreen navigation={mockNavigation} />);
+
+    fireEvent.press(getByText("Create Account"));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        "Please accept the Terms and Conditions before signing up."
+      );
+    });
+  });
+
+  it("creates user and navigates to Home when valid", async () => {
+    const { createUserWithEmailAndPassword, signInWithEmailAndPassword } = require("firebase/auth");
+
+    createUserWithEmailAndPassword.mockResolvedValue({});
+    signInWithEmailAndPassword.mockResolvedValue({});
+
+    const { getByPlaceholderText, getByText, getByTestId } = render(
+      <SignUpScreen navigation={mockNavigation} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText("Enter your email"), "user@example.com");
+    fireEvent.changeText(getByPlaceholderText("Enter your password"), "password123");
+
+    // Accept Terms and Conditions
+    fireEvent.press(getByTestId("checkbox")); // The checkbox
+
+    fireEvent.press(getByText("Create Account"));
+
+    await waitFor(() => {
+      expect(createUserWithEmailAndPassword).toHaveBeenCalled();
+      expect(signInWithEmailAndPassword).toHaveBeenCalled();
+      expect(Alert.alert).toHaveBeenCalledWith("Account created and logged in successfully!");
+      expect(mockNavigation.navigate).toHaveBeenCalledWith("Home");
+    });
+  });
+
+  it("opens and closes Terms modal", () => {
+    const { getByText, getByRole } = render(<SignUpScreen navigation={mockNavigation} />);
+
+    fireEvent.press(getByText(/I accept the/i));
+    expect(getByText(/UNLV Reserved Parking Terms and Conditions/i)).toBeTruthy();
+
+    fireEvent.press(getByText("Close"));
+    // The modal should close; no assertion needed here unless using `queryByText`
+  });
+
+  it("navigates back to login screen", () => {
+    const { getByText } = render(<SignUpScreen navigation={mockNavigation} />);
+    fireEvent.press(getByText("Back to Login"));
+    expect(mockNavigation.goBack).toHaveBeenCalled();
+  });
+});

--- a/screens/signUpScreen.js
+++ b/screens/signUpScreen.js
@@ -182,7 +182,7 @@ Please review and accept the Terms and Conditions before creating an account.
 
         {/* Terms and Conditions */}
         <View style={styles.termsRow}>
-          <TouchableOpacity onPress={() => setTermsAccepted(!termsAccepted)}>
+          <TouchableOpacity onPress={() => setTermsAccepted(!termsAccepted)} testID="checkbox">
             <View style={[styles.checkbox, termsAccepted && styles.checkboxChecked]}>
               {termsAccepted && <Text style={styles.checkmark}>✓</Text>}
             </View>


### PR DESCRIPTION
### This pull request focuses on improving the project’s test coverage by:

**1. Creating and validating unit tests for the following screens:**
   - `SignUpScreen`
   - `LoginScreen`
   - `ParkingScreen` (with mocked ParkingMap)
   - `EditVehicleScreen`
   - `ReservationConfirmationScreen`
   - `ResetPasswordScreen`


**2. Improving testing reliability by:**
   - Replacing unreliable `getByRole` usage with `getByTestId` for checkbox interaction in `SignUpScreen`
   - Mocked the external components like `ParkingMap` to isolate `ParkingScreen` tests
   - Simulating Firebase Auth interactions for login and signup


---

### **Changes & Code Quality Review:**

- **Enhanced Functionality**:
  - I validated expected user interactions and navigation for each screen


- **Improved User Experience**:
  - I ensured authentication and screen transitions work as intended through npm sim


- **Code Readability & Formatting**:
  - I tidied up the test syntax using `@testing-library/react-native` best practices
  - Separated the logic for Firebase and navigation mocking


---

### **Type of Change**

- [x] Test Coverage
- [ ] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Other (please describe):


---

### **Potential Improvements / Issues to Address:**
- Could consider expanding tests for image uploads and Firestore edge cases
- Could think about adding integration level tests in future PRs for full user flows (Integration Testing isn't necessary for this class though but this could be an extra step 😄 )
