### PR TITLE
Update Other two parking Screens

### DIFF
--- a/screens/GatewayParkingScreen.js
+++ b/screens/GatewayParkingScreen.js
@@ -12,6 +12,7 @@ import { useNavigation } from '@react-navigation/native'
 import { GestureDetector, Gesture } from 'react-native-gesture-handler'
 import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated'
 import gatewayMap from '../assets/gatewayPark.png' // your uploaded blueprint
+import { getDoc } from "firebase/firestore";
 
 const db = getFirestore()
 const auth = getAuth()
@@ -97,7 +98,36 @@ const ParkingMap = ({ parkingLot = 'Gateway Parking' }) => {
     return () => unsubscribe()
   }, [])
 
+  const userHasVehicles = async () => {
+    const user = auth.currentUser;
+    if (!user) return false;
+
+    const vehicleDocRef = doc(db, "vehicles", user.uid);
+    const vehicleSnap = await getDoc(vehicleDocRef);
+    if (vehicleSnap.exists()) {
+      const data = vehicleSnap.data();
+      return data.vehicles && data.vehicles.length > 0;
+    }
+    return false;
+  };
+
   const handleReserve = async () => {
+    const hasVehicles = await userHasVehicles();
+    if (!hasVehicles) {
+      Alert.alert(
+        "No Vehicle Found",
+        "Please add a vehicle before reserving a parking spot.",
+        [
+          {
+            text: "Add Vehicle",
+            onPress: () => navigation.navigate("AddVehicle"),
+          },
+          { text: "Cancel", style: "cancel" },
+        ]
+      );
+      return;
+    }
+
     if (!selectedSpot) return Alert.alert('No spot selected', 'Please select one.')
     try {
       const user = auth.currentUser


### PR DESCRIPTION
Now the parking screens match with the Cottage grove parking screen when someone is trying to reserve a parking space but there is no vehicle, it will ask the user to add a vehicle before they can reserve first

### This pull request focuses on improving the TropicanaParkingScreen.js file and the GatewayParkingScreen.js file by:

1. Aligning the behavior of Tropicana and Gateway parking screens with Cottage Grove regarding vehicle verification before reservation.

### Changes & Code Quality Review:
 _**Enhanced Functionality**:_

- Added checks in TropicanaParkingScreen.js and GatewayParkingScreen.js to ensure a user has a registered vehicle before allowing a reservation.

_**Improved User Experience:**_

- Users will now see a prompt to add a vehicle if none is registered, preventing confusion and matching behavior across all garage screens.

_**Code Readability & Formatting:**_

- Logic for vehicle validation is clearly implemented and consistent with the Cottage Grove screen.
- Code remains clean and easy to follow.

### Type of Change

- [ ]  Bugfix
- [X]  New Feature
- [ ]  Documentation Update
- [ ]  Other (please describe):

### Potential Improvements / Issues to Address:

- Consider abstracting the vehicle check logic into a shared utility to reduce code duplication across parking screens.


